### PR TITLE
fixed a bug with 'tarn' library on knex > 0.14.2

### DIFF
--- a/lib/knex.js
+++ b/lib/knex.js
@@ -14,8 +14,8 @@ function connect() {
 		client: 'mysql',
 		connection: conn,
 		pool: {
-			min: process.env.MYSQL_POOL_MIN || 2,
-			max: process.env.MYSQL_POOL_MAX || 10
+			min: +process.env.MYSQL_POOL_MIN || 2,
+			max: +process.env.MYSQL_POOL_MAX || 10
 		}
 	});
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/amkjs/amk-sql.git"
+    "url": "https://github.com/amkjs/amk-sql.git"
   },
   "keywords": [
     "amk",


### PR DESCRIPTION
tarn does not automatically typecast the string value from env variables, so have to typecast it manually.

able to reproduce it by using the latest library and putting `MYSQL_POOL_MIN=1`:
```
Error: Tarn: opt.min must be an integer >= 0
    at new Pool (/Users/heinrichchan/Documents/Project/ap-backend/node_modules/tarn/lib/Pool.js:25:13)
    at Client_MySQL.initializePool (/Users/heinrichchan/Documents/Project/ap-backend/node_modules/knex/lib/client.js:320:17)
    at Client_MySQL.Client (/Users/heinrichchan/Documents/Project/ap-backend/node_modules/knex/lib/client.js:117:12)
    at new Client_MySQL (/Users/heinrichchan/Documents/Project/ap-backend/node_modules/knex/lib/dialects/mysql/index.js:62:20)
    at Knex (/Users/heinrichchan/Documents/Project/ap-backend/node_modules/knex/lib/index.js:60:34)
    at connect (/Users/heinrichchan/Documents/Project/ap-backend/node_modules/amk-sql/lib/knex.js:13:9)
    at Object.<anonymous> (/Users/heinrichchan/Documents/Project/ap-backend/node_modules/amk-sql/lib/sql.js:6:10)
    at Module._compile (module.js:652:30)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
    at Module.require (module.js:596:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/Users/heinrichchan/Documents/Project/ap-backend/node_modules/amk-sql/index.js:2:13)
    at Module._compile (module.js:652:30)
```